### PR TITLE
Implement full document reparsing on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parser support for function definitions and function calls.
 - Function go to definition.
 - Function go to references.
+- Reparsing of document on changes.
 
 ### Changed
 - Keyword documentation hover message type from markdown to plaintext.

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -5,9 +5,10 @@ use std::sync::{Arc, Mutex};
 
 use jsonrpc_core::{IoHandler, Params};
 use lsp_types::{
-    DidOpenTextDocumentParams, GotoDefinitionParams, GotoDefinitionResponse, HoverParams,
-    HoverProviderCapability, InitializeParams, InitializeResult, ReferenceParams,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams, GotoDefinitionParams,
+    GotoDefinitionResponse, HoverParams, HoverProviderCapability, InitializeParams,
+    InitializeResult, ReferenceParams, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind,
 };
 use regex::Regex;
 use serde_json::{self, from_value, to_value, Value};
@@ -69,6 +70,14 @@ fn setup_handler() -> IoHandler {
         let notification = from_value::<DidOpenTextDocumentParams>(value).unwrap();
 
         state_c.lock().unwrap().did_open(&notification);
+    });
+
+    let state_c = state.clone();
+    io.add_notification("textDocument/didChange", move |params| {
+        let value = params_to_value(params);
+        let notification = from_value::<DidChangeTextDocumentParams>(value).unwrap();
+
+        state_c.lock().unwrap().did_change(&notification);
     });
 
     let state_c = state.clone();


### PR DESCRIPTION
Closes #1 

Allows the language server to update the file's AST by reparsing the document when it is changed by the user.

## Checklist
* [x] Update changelog